### PR TITLE
Add onecommit pre-commit hook definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+---
+name: ci
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.1
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: onecommit
+        name: onecommit
+        entry: ./scripts/onecommit.sh
+        language: system
+        always_run: true
+        verbose: true
+        # debug: true
+        pass_filenames: false
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,14 @@
+---
+# For use with pre-commit.
+# See usage instructions at http://pre-commit.com
+
+- id: onecommit
+  name: onecommit
+  description: >
+    Ensures that the proposed change has only one commit on GitHub or GitLab.
+  entry: python3 -m ansiblelint -v --force-color
+  language: python
+  # do not pass files to ansible-lint, see:
+  # https://github.com/ansible/ansible-lint/issues/611
+  pass_filenames: false
+  always_run: true

--- a/scripts/onecommit.sh
+++ b/scripts/onecommit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# gitlab logic
+if [ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]; then
+    COMMIT_COUNT=$(git rev-list "$CI_MERGE_REQUEST_DIFF_BASE_SHA...$CI_COMMIT_SHA" --count)
+# github logic
+elif [ -f "${GITHUB_EVENT_PATH:-}" ]; then
+    PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")
+    # elif [[ -n "${PR_NUMBER:-}" ]] && [[ -n "${GITHUB_ACTION:-}" ]]; then
+    # get the number of commits in the PR
+    PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+    if [ "$PR_NUMBER" != "null" ]; then
+        COMMIT_COUNT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits | length')
+        echo "PR_NUMBER: $PR_NUMBER"
+        echo "COMMIT_COUNT: $COMMIT_COUNT"
+    else
+        echo "No PR number found, skipping onecommit check."
+        exit 0
+    fi
+else
+    echo "No GitHub or GitHub CI environment detected, skipping onecommit check."
+    exit 0
+fi
+
+if [ "$COMMIT_COUNT" -gt 1 ]; then
+    echo "Error: The proposed change has more than one commit, squash all commits to allow merge."
+    exit 1
+fi


### PR DESCRIPTION
This adds a reusable hook definition for pre-commit, so we can point to this repository for using it. It does not have any implicit effects.

Also this change enables some minimal testing pipelines for this repository.